### PR TITLE
Delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-hcysun.me


### PR DESCRIPTION
域名过期了，访问博客会被重定向到过期的域名